### PR TITLE
Use TLS 1.2, bump version

### DIFF
--- a/DomainConnect/Properties/AssemblyInfo.cs
+++ b/DomainConnect/Properties/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DomainConnect")]
-[assembly: AssemblyCopyright("Copyright 2018")]
+[assembly: AssemblyCopyright("Copyright © DomainConnect.org 2018-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.1.*")]

--- a/DomainConnect/RestAPIHelper.cs
+++ b/DomainConnect/RestAPIHelper.cs
@@ -16,6 +16,7 @@ namespace RestAPIHelper
         //
         public static string GET(string url, out int status)
         {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             HttpWebResponse response = null;
             status = 0;
             try
@@ -56,6 +57,7 @@ namespace RestAPIHelper
         //
         public static string POST(string url, Dictionary<string, string> headers, out int status)
         {
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             HttpWebResponse response = null;
             status = 0;
             try

--- a/DomainConnectDDNSSetup/Properties/AssemblyInfo.cs
+++ b/DomainConnectDDNSSetup/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("DomainConnect.org")]
 [assembly: AssemblyProduct("DomainConnectDDNSSetup")]
-[assembly: AssemblyCopyright("Copyright © DomainConnect.org 2017")]
+[assembly: AssemblyCopyright("Copyright © DomainConnect.org 2017-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/DomainConnectDDNSUpdate/Properties/AssemblyInfo.cs
+++ b/DomainConnectDDNSUpdate/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DomainConnectDDNSUpdate")]
-[assembly: AssemblyCopyright("Copyright ©  DomainConnect.org, 2017")]
+[assembly: AssemblyCopyright("Copyright © DomainConnect.org 2017-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/DomainConnectDDNSUpdateTray/Properties/AssemblyInfo.cs
+++ b/DomainConnectDDNSUpdateTray/Properties/AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("DomainConnectDDNSUpdateTray")]
-[assembly: AssemblyCopyright("Copyright 2018")]
+[assembly: AssemblyCopyright("Copyright © DomainConnect.org 2018-2022")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -28,4 +28,4 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and 
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.1.*")]


### PR DESCRIPTION
This PR fixes #7 which currently prevents this application from working with any DomainConnect provider which requires TLS 1.2, including apparently GoDaddy. I tested that I was able to update DDNS entry with this change, and I bumped the version numbers of all of the projects to make it easy to verify what version is installed, which may be useful for future bug reports.

Note that if you'd like me to commit a built release binary, I am happy to do so.

Also note that this project does not currently appear to list an open source license. I am not sure if @arnoldblinn or @pawel-kow would be able to officially add an MIT License to this project or not like the Python client. However, to avoid any question about *my* changes: I grant the Domain-Connect org complete rights to my contributions to this project, including the right to re-license my contributions as they see fit.